### PR TITLE
レース数に「6レース」の選択肢を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         <h4>レース数</h4>
         <p class="radio-wrapper">
         	<input type="radio" id="race-num-4" class="race-num-radio" name="race-num" value="4"><label for="race-num-4">4レース</label>
+        	<input type="radio" id="race-num-6" class="race-num-radio" name="race-num" value="6"><label for="race-num-6">6レース</label>
         	<input type="radio" id="race-num-8" class="race-num-radio" name="race-num" value="8"><label for="race-num-8">8レース</label>
         	<input type="radio" id="race-num-12" class="race-num-radio" name="race-num" value="12"><label for="race-num-12">12レース</label>
         	<input type="radio" id="race-num-24" class="race-num-radio" name="race-num" value="24"><label for="race-num-24">24レース</label>


### PR DESCRIPTION
[レース数の選択肢に「6レース」が欲しい](https://github.com/GungeeSpla/mk8dx_sokuji/issues/1)
こちらのIssueの修正プルリクエストになります。
お手隙のときで構いませんので確認とよろしければマージをお願いできますでしょうか。

以下修正内容と確認観点になります。

## 修正内容
- レース数の選択肢に「6レース」を追加

## 確認観点
- レース数の選択肢に「6レース」が表示されていること
	- 初期表示時は「12レース」が選択されていること
	- 「6レース」を選択後、ブラウザをリロードしたときに初期表示で「6レース」が選択されていること
- レース数を切り替えた時に、「順位」部分が6列になること
- 即時集計結果の残りレース数が@6になること
	- また1レースの結果を埋めた時に@5となること
	- 全てのレースの結果を埋めた時に@0となること
- 上記の観点をoverlayモードで確認
	- 加えてレース数「6レース」選択時、overlayの「残レース」に「6」と表示されていること

※レース数は計算の基点となる数字であり、計算の処理には一切手をつけていないため計算結果の整合性は確認しておりません。